### PR TITLE
fix_api

### DIFF
--- a/api/components/responses/BadRequest.yml
+++ b/api/components/responses/BadRequest.yml
@@ -10,4 +10,4 @@ content:
         message:
           type: array
           items:
-            example: "〇〇を入力してください"
+            example: "不正な入力値です。"

--- a/api/components/schemas/Admin/Notification.yml
+++ b/api/components/schemas/Admin/Notification.yml
@@ -27,15 +27,10 @@ properties:
   employee:
     type: object
     $ref: "../EmployeeOnlyName.yml"
-  startTime:
+  shiftTime:
     type: string
-    example: "2030/01/01 18:00"
-  endTime:
-    type: string
-    example: "2030/01/01 23:00"
+    example: "2030/01/01 18:00-23:00"
 required:
   - "id"
   - "read"
-  - "kind"
-  - "itemId"
   - "status"

--- a/api/components/schemas/Admin/Shift.yml
+++ b/api/components/schemas/Admin/Shift.yml
@@ -16,6 +16,9 @@ properties:
       - approved
       - absenceApplication
     example: "unapproved"
+  absenceId:
+    type: integer
+    example: 1
   employee:
     type: object
     $ref: "../EmployeeOnlyName.yml"

--- a/api/components/schemas/Employee/Notification.yml
+++ b/api/components/schemas/Employee/Notification.yml
@@ -24,15 +24,10 @@ properties:
       - rejected
       - unapplied
     example: "application"
-  startTime:
+  shiftTime:
     type: string
-    example: "2030/01/01 18:00"
-  endTime:
-    type: string
-    example: "2030/01/01 23:00"
+    example: "2030/01/01 18:00-23:00"
 required:
   - "id"
   - "read"
-  - "kind"
-  - "itemId"
   - "status"

--- a/api/components/schemas/ShiftForAbsence.yml
+++ b/api/components/schemas/ShiftForAbsence.yml
@@ -9,18 +9,7 @@ properties:
   endTime:
     type: string
     example: "2030/01/01 23:00"
-  status:
-    type: string
-    enum:
-      - unapproved
-      - approved
-      - absenceApplication
-    example: "unapproved"
-  absenceId:
-    type: integer
-    example: 1
 required:
   - "id"
   - "startTime"
   - "endTime"
-  - "status"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -19,16 +19,18 @@ tags:
     description: "devise関連の操作"
 
 paths:
-  /api/v1/admin/current-admin:
-    $ref: "./paths/admin/currentAdmin.yml"
   /api/v1/admin/admins:
     $ref: "./paths/admin/admins.yml"
   /api/v1/admin/admins/{id}:
     $ref: "./paths/admin/adminById.yml"
+  /api/v1/admin/admins/profile:
+    $ref: "./paths/admin/currentAdmin.yml"
   /api/v1/admin/employees:
     $ref: "./paths/admin/employees.yml"
   /api/v1/admin/employees/{id}:
     $ref: "./paths/admin/employeeById.yml"
+  /api/v1/admin/employees/unapplied_employees:
+    $ref: "./paths/admin/unappliedEmployees.yml"
   /api/v1/admin/shifts:
     $ref: "./paths/admin/shifts.yml"
   /api/v1/admin/shifts/{id}:
@@ -37,22 +39,26 @@ paths:
     $ref: "./paths/admin/absenceById.yml"
   /api/v1/admin/notifications:
     $ref: "./paths/admin/notifications.yml"
-  /api/v1/admin/unapplied-employees:
-    $ref: "./paths/admin/unappliedEmployees.yml"
-  /api/v1/employee/current-employee:
-    $ref: "./paths/employee/currentEmployee.yml"
+  /api/v1/admin/notifications/{id}:
+    $ref: "./paths/admin/notificationById.yml"
   /api/v1/employee/shifts:
     $ref: "./paths/employee/shifts.yml"
   /api/v1/employee/shifts/{id}:
     $ref: "./paths/employee/shiftById.yml"
   /api/v1/employee/absences:
     $ref: "./paths/employee/absences.yml"
+  /api/v1/employee/absences/new:
+    $ref: "./paths/employee/absenceNew.yml"
   /api/v1/employee/absences/{id}:
     $ref: "./paths/employee/absenceById.yml"
   /api/v1/employee/notifications:
     $ref: "./paths/employee/notifications.yml"
+  /api/v1/employee/notifications/{id}:
+    $ref: "./paths/employee/notificationById.yml"
   /api/v1/employee/mypage:
     $ref: "./paths/employee/mypage.yml"
+  /api/v1/employee/mypage/profile:
+    $ref: "./paths/employee/currentEmployee.yml"
   /api/v1/admin_auth:
     $ref: "./paths/adminAuth/admin.yml"
   /api/v1/admin_auth/sign_in:

--- a/api/paths/admin/employeeById.yml
+++ b/api/paths/admin/employeeById.yml
@@ -29,3 +29,20 @@ get:
       $ref: "../../components/responses/NotFound.yml"
     "500":
       $ref: "../../components/responses/InternalServerError.yml"
+delete:
+  summary: "従業員削除"
+  tags: ["admin"]
+  operationId: deleteEmployee
+  deprecated: false
+  $ref: "../../components/security/auth.yml"
+  responses:
+    "204":
+      description: "Success"
+    "400":
+      $ref: "../../components/responses/BadRequest.yml"
+    "401":
+      $ref: "../../components/responses/Unauthorized.yml"
+    "403":
+      $ref: "../../components/responses/Forbidden.yml"
+    "500":
+      $ref: "../../components/responses/InternalServerError.yml"

--- a/api/paths/admin/notificationById.yml
+++ b/api/paths/admin/notificationById.yml
@@ -1,0 +1,25 @@
+patch:
+  summary: "通知の既読/未読の変更"
+  tags: ["admin"]
+  operationId: updateNotificationForAdmin
+  deprecated: false
+  parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+  $ref: "../../components/security/auth.yml"
+  responses:
+    "204":
+      description: "Success"
+    "400":
+      $ref: "../../components/responses/BadRequest.yml"
+    "401":
+      $ref: "../../components/responses/Unauthorized.yml"
+    "403":
+      $ref: "../../components/responses/Forbidden.yml"
+    "404":
+      $ref: "../../components/responses/NotFound.yml"
+    "500":
+      $ref: "../../components/responses/InternalServerError.yml"

--- a/api/paths/employee/absenceNew.yml
+++ b/api/paths/employee/absenceNew.yml
@@ -1,0 +1,26 @@
+get:
+  summary: "欠勤申請可能なシフトの取得"
+  tags: ["employee"]
+  operationId: getNewAbsence
+  deprecated: false
+  $ref: "../../components/security/auth.yml"
+  responses:
+    "200":
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: "../../components/schemas/ShiftForAbsence.yml"
+    "401":
+      $ref: "../../components/responses/Unauthorized.yml"
+    "403":
+      $ref: "../../components/responses/Forbidden.yml"
+    "404":
+      $ref: "../../components/responses/NotFound.yml"
+    "500":
+      $ref: "../../components/responses/InternalServerError.yml"

--- a/api/paths/employee/notificationById.yml
+++ b/api/paths/employee/notificationById.yml
@@ -1,0 +1,25 @@
+patch:
+  summary: "通知の既読/未読の変更"
+  tags: ["employee"]
+  operationId: updateNotificationForEmployee
+  deprecated: false
+  parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+  $ref: "../../components/security/auth.yml"
+  responses:
+    "204":
+      description: "Success"
+    "400":
+      $ref: "../../components/responses/BadRequest.yml"
+    "401":
+      $ref: "../../components/responses/Unauthorized.yml"
+    "403":
+      $ref: "../../components/responses/Forbidden.yml"
+    "404":
+      $ref: "../../components/responses/NotFound.yml"
+    "500":
+      $ref: "../../components/responses/InternalServerError.yml"

--- a/api/paths/employeeAuth/employee.yml
+++ b/api/paths/employeeAuth/employee.yml
@@ -46,20 +46,3 @@ put:
       $ref: "../../components/responses/Forbidden.yml"
     "500":
       $ref: "../../components/responses/InternalServerError.yml"
-delete:
-  summary: "従業員削除"
-  tags: ["auth"]
-  operationId: deleteEmployee
-  deprecated: false
-  $ref: "../../components/security/auth.yml"
-  responses:
-    "204":
-      description: "Success"
-    "400":
-      $ref: "../../components/responses/BadRequest.yml"
-    "401":
-      $ref: "../../components/responses/Unauthorized.yml"
-    "403":
-      $ref: "../../components/responses/Forbidden.yml"
-    "500":
-      $ref: "../../components/responses/InternalServerError.yml"


### PR DESCRIPTION
backendでレスポンスを作成していたところ、必要な修正を行いました！

- エラー時のレスポンス文言修正
- 通知一覧画面で使用する時間を取得したときの、形式の修正
- シフト一覧(シフトカレンダー)にabsence_id の追加 (シフトカレンダーでabsenceに遷移できるようにするため)
- 欠勤申請時に使用するシフト情報のエンドポイント作成
- 通知の既読/未読を変更するためのエンドポイント作成
- URLの一部変更 (current_employee,current_admin, などを使うと、deviseの標準であるcurrent〇〇と被っておかしな挙動になってしまう)
- 従業員削除をauth関連のエンドポイントから、admin関連に移動。( admin側で従業員を削除できるようにするため )